### PR TITLE
AnyStringCodingKey

### DIFF
--- a/Sources/WPFoundation/AnyStringCodingKey.swift
+++ b/Sources/WPFoundation/AnyStringCodingKey.swift
@@ -1,0 +1,28 @@
+// MARK: - AnyStringCodingKey
+
+/// A `CodingKey` that is always an arbitrary string.
+public struct AnyStringCodingKey: CodingKey, Hashable, Sendable {
+  public var stringValue: String
+
+  public init(stringValue: String) {
+    self.stringValue = stringValue
+  }
+
+  public var intValue: Int?
+
+  public init?(intValue: Int) {
+    return nil
+  }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension AnyStringCodingKey: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.stringValue = value
+  }
+}
+
+// MARK: - ExprressibleByStringInterpolation
+
+extension AnyStringCodingKey: ExpressibleByStringInterpolation {}

--- a/Sources/WPHaptics/AHAPPattern.swift
+++ b/Sources/WPHaptics/AHAPPattern.swift
@@ -1,4 +1,4 @@
-import Foundation
+import WPFoundation
 
 // MARK: - AHAPPattern
 
@@ -378,8 +378,10 @@ extension AHAPPattern.Event: Encodable {
 }
 
 extension AHAPPattern.Event: Decodable {
+  public typealias CodingKeys = AnyStringCodingKey
+
   public init(from decoder: any Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKey.self)
+    let container = try decoder.container(keyedBy: AnyStringCodingKey.self)
     switch try container.decode(AHAPPattern.EventType.self, forKey: .eventType) {
     case .audioContinuous:
       self = try .audioContinuous(AHAPPattern.AudioContinuousEvent(from: decoder))
@@ -391,21 +393,10 @@ extension AHAPPattern.Event: Decodable {
       self = try .hapticTransient(AHAPPattern.HapticTransientEvent(from: decoder))
     }
   }
+}
 
-  private struct CodingKey: Swift.CodingKey {
-    static let eventType = Self(stringValue: "EventType")
-
-    var stringValue: String
-    var intValue: Int?
-
-    init(stringValue: String) {
-      self.stringValue = stringValue
-    }
-
-    init?(intValue: Int) {
-      return nil
-    }
-  }
+extension AnyStringCodingKey {
+  fileprivate static let eventType = Self(stringValue: "EventType")
 }
 
 // MARK: - Event Type


### PR DESCRIPTION
Noticed that I would create private coding key types that only accept strings when working with complex codables, so I decided to make a dedicated type for it.