### PR TITLE
GRDB SQL literal overloads for fetching

### DIFF
--- a/Sources/WPGRDB/DatabaseLogHandler.swift
+++ b/Sources/WPGRDB/DatabaseLogHandler.swift
@@ -80,7 +80,10 @@
     public func all() async throws -> [DatabaseLog] {
       try await self.writer?
         .read {
-          try DatabaseLog.fetchAll($0, sql: "SELECT * FROM WPGRDBDatabaseLogs ORDER BY date DESC")
+          try DatabaseLog.fetchAll(
+            $0,
+            literal: "SELECT * FROM WPGRDBDatabaseLogs ORDER BY date DESC"
+          )
         } ?? []
     }
   }

--- a/Sources/WPGRDB/FetchLiteral.swift
+++ b/Sources/WPGRDB/FetchLiteral.swift
@@ -1,0 +1,261 @@
+#if canImport(GRDB)
+  import GRDB
+
+  // MARK: - DatabaseValueConvertible
+
+  extension DatabaseValueConvertible where Self: StatementColumnConvertible {
+    /// Returns a single value fetched from an SQL query.
+    ///
+    /// The value is decoded from the leftmost column if the `adapter` argument
+    /// is nil.
+    ///
+    /// The result is nil if the request returns no row, or one row with a
+    /// `NULL` value.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let score = try Int.fetchOne(db, literal: "SELECT score FROM player WHERE lastName = \(lastName)")
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: An optional value.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchOne(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> Self? {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchOne(db, request)
+    }
+
+    /// Returns an array of values fetched from an SQL query.
+    ///
+    /// The value is decoded from the leftmost column if the `adapter` argument
+    /// is nil.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let scores = try Int.fetchAll(db, literal: "SELECT score FROM player WHERE lastName = \(lastName)")
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: An array of values.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchAll(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> [Self] {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchAll(db, request)
+    }
+
+    /// Returns a set of values fetched from an SQL query.
+    ///
+    /// The value is decoded from the leftmost column if the `adapter` argument
+    /// is nil.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let scores = try Int.fetchSet(db, literal: "SELECT score FROM player WHERE lastName = \(lastName)")
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: A set of values.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchSet(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> Set<Self> where Self: Hashable {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchSet(db, request)
+    }
+
+    /// Returns a cursor over values fetched from an SQL query.
+    ///
+    /// The value is decoded from the leftmost column if the `adapter` argument
+    /// is nil.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let scoresCursor = try Int.fetchCurder(db, literal: "SELECT score FROM player WHERE lastName = \(lastName)")
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: A `FastDatabaseCursor` over the fetched values.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchCursor(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> FastDatabaseValueCursor<Self> {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchCursor(db, request)
+    }
+  }
+
+  // MARK: - FetchableRecord
+
+  extension FetchableRecord {
+    /// Returns a single record fetched from an SQL query.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let player = try Player.fetchOne(
+    ///       db,
+    ///       literal: "SELECT * FROM player WHERE lastName = \(lastName) LIMIT 1"
+    ///     )
+    /// }
+    /// ```
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: An optional record.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchOne(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> Self? {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchOne(db, request)
+    }
+
+    /// Returns an array of records fetched from an SQL query.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let players = try Player.fetchAll(
+    ///       db,
+    ///       literal: "SELECT * FROM player WHERE lastName = \(lastName)"
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: An array of records.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchAll(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> [Self] {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchAll(db, request)
+    }
+
+    /// Returns a set of records fetched from an SQL query.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let players = try Player.fetchSet(
+    ///       db,
+    ///       literal: "SELECT * FROM player WHERE lastName = \(lastName)"
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: A set of records.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchSet(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> Set<Self> where Self: Hashable {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchSet(db, request)
+    }
+
+    /// Returns a cursor over records fetched from an SQL query.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let lastName = "O'Reilly"
+    ///     let players = try Player.fetchCursor(
+    ///       db,
+    ///       literal: "SELECT * FROM player WHERE lastName = \(lastName)"
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - literal: An `SQL` literal.
+    ///     - adapter: Optional RowAdapter.
+    ///     - cached: Defaults to false. If true, the request reuses a cached prepared statement.
+    /// - returns: A `RecordCursor` over fetched values.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    public static func fetchCursor(
+      _ db: Database,
+      literal: SQL,
+      adapter: RowAdapter? = nil,
+      cached: Bool = false
+    ) throws -> RecordCursor<Self> {
+      let request = SQLRequest(literal: literal, adapter: adapter, cached: cached)
+      return try Self.fetchCursor(db, request)
+    }
+  }
+#endif

--- a/Tests/WPGRDBTests/DatabaseFunction+Xoshiro256Tests.swift
+++ b/Tests/WPGRDBTests/DatabaseFunction+Xoshiro256Tests.swift
@@ -36,7 +36,7 @@
       let values = try await sqlite.read { db in
         try (0..<5)
           .map { _ in
-            try Int64.fetchOne(db, sql: "SELECT XOSHIRO256(?)", arguments: [seed])!
+            try Int64.fetchOne(db, literal: "SELECT XOSHIRO256(\(seed))")!
           }
       }
       expectNoDifference(values, expected)

--- a/Tests/WPGRDBTests/SingleRowTableTests.swift
+++ b/Tests/WPGRDBTests/SingleRowTableTests.swift
@@ -40,7 +40,7 @@
         }
         try await queue.write { db in
           try db.execute(literal: "INSERT INTO test (id, text) VALUES (1, 'hello')")
-          let strings = try String.fetchAll(db, sql: "SELECT text FROM test")
+          let strings = try String.fetchAll(db, literal: "SELECT text FROM test")
           #expect(strings == ["hello"])
         }
       }


### PR DESCRIPTION
I prefer to use GRDB with raw sql, but for some reason explicit `literal` overloads on the series of `fetchXXX` methods were missing unlike when running `Database.execute(literal:)`. This caused a weird divide in styles where I got to use literals for pure write statements (insertions, updates, deletes), but had to fallback to the more inconvenient way of manually binding values for fetch statements using `fetchAll(sql:arguments:)` overload.
